### PR TITLE
fix!: use correct keyboard arrows in radio tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@etchteam/storybook-addon-a11y-interaction-tests",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Storybook addon for accessibility interaction tests",
   "keywords": [
     "storybook-addons",

--- a/src/a11y-tests/radio.ts
+++ b/src/a11y-tests/radio.ts
@@ -167,14 +167,7 @@ export const a11yRadio = async ({
       // Right Arrow and Down Arrow: move focus to the next radio button in the group,
       // uncheck the previously focused button, and check the newly focused button.
       // If focus is on the last button, focus moves to the first button.
-
-      // Hey Developer!
-      // There's a bug in @testing-library/user-event that makes the keypresses on
-      // radio buttons backwards. This should be fixed in 14.6.1, but 14.5.2 is bundled
-      // with ../utils/test-utils in index.mjs at the time I'm writing this so I can't fix it.
-      // If your tests just fell over they probably fixed it and these arrows need flipping.
-      // https://github.com/testing-library/user-event/pull/1049
-      keys = ['{arrowleft}', '{arrowdown}'];
+      keys = ['{arrowright}', '{arrowdown}'];
       for (const arrow of keys) {
         await userEvent.click(firstRadio);
         await userEvent.keyboard(arrow);
@@ -190,7 +183,7 @@ export const a11yRadio = async ({
       // Left Arrow and Up Arrow: move focus to the previous radio button in the group,
       // uncheck the previously focused button, and check the newly focused button.
       // If focus is on the first button, focus moves to the last button.
-      keys = ['{arrowright}', '{arrowup}'];
+      keys = ['{arrowleft}', '{arrowup}'];
       for (const arrow of keys) {
         await userEvent.click(firstRadio);
         await userEvent.keyboard(arrow);


### PR DESCRIPTION
Current storybook (9.0.18) comes with @testing-library/user-event@14.6.1 which fixes the behaviour of arrow keys on radio buttons.